### PR TITLE
Update os_server.py to include option for files

### DIFF
--- a/lib/ansible/modules/cloud/openstack/os_server.py
+++ b/lib/ansible/modules/cloud/openstack/os_server.py
@@ -132,6 +132,13 @@ options:
         - Whether to boot the server with config drive enabled
      required: false
      default: 'no'
+   files:
+     description:
+       - Files to insert into the instance.
+         Equivalent of files= option in nova boot for personality
+     required: false
+     default: null
+     version_added: "2.3"
    userdata:
      description:
         - Opaque blob of data which is made available to the instance
@@ -413,6 +420,20 @@ EXAMPLES = '''
           ifdown eth0 && ifup eth0
           {% endraw %}
 
+# Creates a new instance and passes a file via config-drive option
+- name: launch a virtual-router instance
+  hosts: localhost
+  task:
+    - name: launch instance
+      os_server:
+        name: csr1kv
+        image: csr1kv
+        flavor: small.csr1000v
+        nics:
+          - net-id: 34605f38-e52a-25d2-b6ec-754a13ffb723
+        config_drive: true
+        files: iosxe_config.txt="{{ lookup('template', 'files/day0.j2') }}
+        state: present
 '''
 
 try:
@@ -528,6 +549,7 @@ def _create_server(module, cloud):
         security_groups=module.params['security_groups'],
         userdata=module.params['userdata'],
         config_drive=module.params['config_drive'],
+        files=module.params['files'],
     )
     for optional_param in (
             'key_name', 'availability_zone', 'network',
@@ -654,6 +676,7 @@ def main():
         meta                            = dict(default=None, type='raw'),
         userdata                        = dict(default=None, aliases=['user_data']),
         config_drive                    = dict(default=False, type='bool'),
+        files                           = dict(default=[], type='dict'),
         auto_ip                         = dict(default=True, type='bool', aliases=['auto_floating_ip', 'public_ip']),
         floating_ips                    = dict(default=None, type='list'),
         floating_ip_pools               = dict(default=None, type='list'),


### PR DESCRIPTION
Adds files options to os_server.py module to allow files to be passed to instance when config-drive option is present.

##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->

<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Feature Pull Request
 - New Module Pull Request
 - Bugfix Pull Request
 - Docs Pull Request

##### COMPONENT NAME
<!--- Name of the module/plugin/module/task -->

##### ANSIBLE VERSION
<!--- Paste verbatim output from “ansible --version” between quotes below -->
```

```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
```

```
